### PR TITLE
fix(trip): migrate to StateFlow and fix continuous recomposition

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    
     - name: set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -22,5 +22,16 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+
+    - name: Run Unit Tests
+      run: ./gradlew test
+
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
+
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-test-reports
+        path: '**/build/reports/tests/'

--- a/data/src/main/java/com/anwera97/data/dao/ExpenditureDao.kt
+++ b/data/src/main/java/com/anwera97/data/dao/ExpenditureDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ExpenditureDao {
-    @Query("SELECT * FROM expenditure WHERE trip_id = :tripId")
+    @Query("SELECT * FROM expenditure WHERE trip_id = :tripId ORDER BY date DESC")
     fun getAllFromTrip(tripId: Int): Flow<List<ExpenditureWithDebtorsAndPayer>>
 
     @Insert

--- a/presentation/src/main/java/com/anwera64/pagodividido/trip/TripActivity.kt
+++ b/presentation/src/main/java/com/anwera64/pagodividido/trip/TripActivity.kt
@@ -4,8 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anwera64.pagodividido.base.BaseComposeViewModelActivity
 import com.anwera64.pagodividido.newexpenditure.NewExpenditureActivity
 import com.anwera64.pagodividido.utils.NOT_FOUND
@@ -37,21 +38,20 @@ class TripActivity : BaseComposeViewModelActivity<TripViewModel>() {
 
     @Composable
     override fun Content() {
-        val expenses = viewModel.getExpenseList(tripId).observeAsState()
+        val expenses by viewModel.expenses.collectAsStateWithLifecycle()
         val title = intent.getStringExtra(NAME)
-        val sortedExpenses = expenses.value?.sortedByDescending { expense -> expense.date }
-        val companions = viewModel.getCompnaions(tripId).observeAsState()
-        val resultModel = viewModel.currentResult.observeAsState()
+        val companions by viewModel.companions.collectAsStateWithLifecycle()
+        val resultModel by viewModel.currentResult.collectAsStateWithLifecycle()
         TripView(
             backNavigation = ::finish,
             createNewExpenditure = ::createNewTrip,
-            expenditures = sortedExpenses.orEmpty(),
+            expenditures = expenses.sortedByDescending { it.date },
             topBarTitle = title.orEmpty(),
-            companionList = companions.value.orEmpty(),
+            companionList = companions,
             requestCompanionResult = { id: String ->
-                viewModel.getResultsForCompanion(tripId, id.toInt())
+                viewModel.selectCompanion(id.toInt())
             },
-            resultModel = resultModel.value
+            resultModel = resultModel
         )
     }
 

--- a/presentation/src/main/java/com/anwera64/pagodividido/trip/TripActivity.kt
+++ b/presentation/src/main/java/com/anwera64/pagodividido/trip/TripActivity.kt
@@ -45,7 +45,7 @@ class TripActivity : BaseComposeViewModelActivity<TripViewModel>() {
         TripView(
             backNavigation = ::finish,
             createNewExpenditure = ::createNewTrip,
-            expenditures = expenses.sortedByDescending { it.date },
+            expenditures = expenses,
             topBarTitle = title.orEmpty(),
             companionList = companions,
             requestCompanionResult = { id: String ->

--- a/presentation/src/main/java/com/anwera64/pagodividido/trip/TripViewModel.kt
+++ b/presentation/src/main/java/com/anwera64/pagodividido/trip/TripViewModel.kt
@@ -1,10 +1,9 @@
 package com.anwera64.pagodividido.trip
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.Observer
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.anwera64.pagodividido.utils.NOT_FOUND
 import com.anwera97.domain.models.CompanionModel
 import com.anwera97.domain.models.ExpenditureModel
 import com.anwera97.domain.models.ResultModel
@@ -12,34 +11,51 @@ import com.anwera97.domain.usecases.CompanionResultUseCase
 import com.anwera97.domain.usecases.CompanionsUseCase
 import com.anwera97.domain.usecases.ExpenditureUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class TripViewModel @Inject constructor(
-    private val expenditureUseCase: ExpenditureUseCase,
-    private val companionsUseCase: CompanionsUseCase,
-    private val companionResultUseCase: CompanionResultUseCase
+    expenditureUseCase: ExpenditureUseCase,
+    companionsUseCase: CompanionsUseCase,
+    private val companionResultUseCase: CompanionResultUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val _currentResult = MediatorLiveData<ResultModel>()
-    /**
-     * Allows the removal of an old source of livedata to prevent errors
-     */
-    private var oldSource: LiveData<ResultModel?>? = null
-    val currentResult: LiveData<ResultModel> = _currentResult
+    private val tripId: Int = savedStateHandle.get<String>(TripActivity.TRIP_ID)?.toInt() ?: NOT_FOUND
 
-    fun getExpenseList(tripUid: Int): LiveData<List<ExpenditureModel>> {
-        return expenditureUseCase.getExpenditures(tripUid).asLiveData()
+    val expenses: StateFlow<List<ExpenditureModel>> = expenditureUseCase
+        .getExpenditures(tripId)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    val companions: StateFlow<List<CompanionModel>> = companionsUseCase
+        .getTripCompanions(tripId)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    private val _selectedCompanionId = MutableSharedFlow<Int>(replay = 1)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentResult: StateFlow<ResultModel?> = _selectedCompanionId
+        .flatMapLatest { companionId ->
+            companionResultUseCase.getPayersWithDebtors(tripId, companionId)
+        }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    init {
+        viewModelScope.launch {
+            val firstCompanion = companions.first { it.isNotEmpty() }.first()
+            _selectedCompanionId.emit(firstCompanion.uid.toInt())
+        }
     }
 
-    fun getResultsForCompanion(tripId: Int, companionUid: Int) {
-        val source = companionResultUseCase.getPayersWithDebtors(tripId, companionUid).asLiveData()
-        oldSource?.let(_currentResult::removeSource)
-        _currentResult.addSource(source, Observer(_currentResult::postValue))
-        oldSource = source
-    }
-
-    fun getCompnaions(tripId: Int): LiveData<List<CompanionModel>> {
-        return companionsUseCase.getTripCompanions(tripId).asLiveData()
+    fun selectCompanion(companionUid: Int) {
+        _selectedCompanionId.tryEmit(companionUid)
     }
 }


### PR DESCRIPTION
- Replace LiveData-returning functions with StateFlow properties so flows are created once in the ViewModel instead of on every recomposition
- Replace MutableStateFlow<Int?> with MutableSharedFlow<Int>(replay=1) for companion selection, removing the null branch in flatMapLatest
- Auto-select the first available companion on load via init block
- Switch TripActivity to collectAsStateWithLifecycle